### PR TITLE
build : function: handle multi-dash and multi-underscore device names in b…

### DIFF
--- a/functions
+++ b/functions
@@ -419,7 +419,7 @@ function build_kernel_deb_package() {
 	local deb_files
 	local build_device_name
 
-	build_device_name=$(echo "${DEVICE_NAME}" | cut -d'_' -f2)
+	build_device_name=$(echo "${DEVICE_NAME}" | cut -d'_' -f2- | tr '_' '-')
 	build_id="$(date +%Y%m%d)-${build_device_name}"
 
 	# shellcheck disable=SC2086


### PR DESCRIPTION
Update `build_device_name` extraction to parse all segments after the first underscore and normalize underscores to hyphens. This prevents device names with multiple underscores or trailing components from being truncated and ensures a valid format for Debian package building.